### PR TITLE
error messages in snackbar

### DIFF
--- a/frontend/src/js/main.tsx
+++ b/frontend/src/js/main.tsx
@@ -7,7 +7,7 @@ import MuiAlert from '@material-ui/lab/Alert';
 
 //Importing from other files in the project
 import Tabs from './tabs';
-import { fetch_user } from "./state/global"
+import { close_toast, fetch_user } from "./state/global"
 import { useCCDispatch, useCCSelector } from './hooks';
 
 function Alert(props) {
@@ -36,7 +36,7 @@ function Main(): React.ReactElement {
         open={open}>
           <React.Fragment >
             <Alert severity={severity} > {message}
-              <IconButton size="small" aria-label="close" color="inherit" >
+              <IconButton size="small" aria-label="close" color="inherit" onClick={() => dispatch(close_toast())}>
                 <CloseIcon fontSize="small" />
               </IconButton>
             </Alert>

--- a/frontend/src/js/state/global.ts
+++ b/frontend/src/js/state/global.ts
@@ -4,6 +4,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 //Importing from other files in the project
 import type { User } from "js/types"
+import { delay } from 'rxjs/operators';
 
 export const globalSlice = createSlice({
     name: 'global',
@@ -28,13 +29,15 @@ export const globalSlice = createSlice({
             state.user = action.payload
         },
         logout: () => {},
-        show_toast: (state, action:PayloadAction<{
-            message: string,
-            severity: 'error'|'warning'|'info'|'success',
-        }>) => {
+        show_toast: (state, action:PayloadAction<string>) => {
             state.toast_open = true
-            state.toast_message = action.payload.message
-            state.toast_severity = action.payload.severity
+            state.toast_message = action.payload
+            state.toast_severity = "success"
+        },
+        show_error: (state, action:PayloadAction<string>) => {
+            state.toast_open = true
+            state.toast_message = action.payload
+            state.toast_severity = "error"
         },
         close_toast: (state) => {
             state.toast_open = false
@@ -43,7 +46,7 @@ export const globalSlice = createSlice({
 })
 
 export const {
-    update_current_tab, fetch_user, update_user, show_toast, close_toast,
+    update_current_tab, fetch_user, update_user, show_toast, show_error, close_toast,
     logout
 } = globalSlice.actions
 export default globalSlice.reducer

--- a/frontend/src/js/state/store.ts
+++ b/frontend/src/js/state/store.ts
@@ -9,7 +9,7 @@ import {
 } from 'rxjs/operators'
 
 //Importing from other files in the project
-import globalReducer from './global'
+import globalReducer, { show_error } from './global'
 import metadataReducer from './metadata'
 import contentReducer from './content'
 import {
@@ -74,9 +74,14 @@ const showToastEpic: MyEpic = action$ =>
         filter(show_toast.match),
         delay(6000),
         map(_ => close_toast()),
-        map(_res=> {console.log("toast closed")
-        return _res}
-        ),
+    )
+
+//Epic to show the error message
+const showErrorEpic: MyEpic = action$ =>
+    action$.pipe(
+        filter(show_error.match),
+        delay(Number.MAX_SAFE_INTEGER),
+        map(_ => close_toast()),
     )
 
 /** METADATA EPICS */
@@ -329,6 +334,7 @@ const epics = combineEpics(
     addContentEpic,
     logoutEpic,
     showToastEpic,
+    showErrorEpic
     // catchErrorEpic // Make sure this epic is last
 )
 

--- a/frontend/src/js/tabs/profile/Page.tsx
+++ b/frontend/src/js/tabs/profile/Page.tsx
@@ -5,7 +5,7 @@ import Typography from "@material-ui/core/Typography"
 
 //Importing from other files in the project
 import { useCCSelector, useCCDispatch } from '../../hooks';
-import { logout, show_toast } from "../../state/global"
+import { logout, show_toast, show_error } from "../../state/global"
 
 export default () => {
     const dispatch = useCCDispatch()
@@ -30,6 +30,5 @@ export default () => {
                 Login
             </Button>
         </>}
-        <Button onClick={() => dispatch(show_toast({message: "Message to display",severity:"info"}))} > Test Button </Button>
-    </div>
+        <Button onClick={() => dispatch(show_error("Message to display"))} > Test Button </Button>    </div>
 }


### PR DESCRIPTION
Created new reducer named "show_error" and new Epic named "showErrorEpic" to handle error messages in snackbar/toasts.

Displaying error messages using these means that the error messages will stick forever, until closed by the user. This gives user enough time to see the message, read it, copy it and troubleshoot.