### PR TITLE
Added Copyright Approved field, fixed editing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8646,7 +8646,7 @@
     },
     "node_modules/solarspell-react-lib": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/SolarSPELL-Main/solarspell-react-lib.git#057c71ad7610791dc8c82435f65bfefd8671ac50",
+      "resolved": "git+ssh://git@github.com/SolarSPELL-Main/solarspell-react-lib.git#0608e19404d15cf96d4b5afc65e93b48d1d0326c",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -16448,7 +16448,7 @@
       }
     },
     "solarspell-react-lib": {
-      "version": "git+ssh://git@github.com/SolarSPELL-Main/solarspell-react-lib.git#057c71ad7610791dc8c82435f65bfefd8671ac50",
+      "version": "git+ssh://git@github.com/SolarSPELL-Main/solarspell-react-lib.git#0608e19404d15cf96d4b5afc65e93b48d1d0326c",
       "from": "solarspell-react-lib@github:SolarSPELL-Main/solarspell-react-lib#main",
       "requires": {
         "@date-io/date-fns": "^1.3.13",

--- a/frontend/src/js/tabs/content/ContentForm.tsx
+++ b/frontend/src/js/tabs/content/ContentForm.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
+import Checkbox from '@material-ui/core/Checkbox';
 
 //Importing from other files in the project
 import { ContentModal, ContentMetadataDisplay } from 'solarspell-react-lib';
@@ -176,18 +177,39 @@ function ContentForm({
                     component: TextField,
                     propFactory: (state, _r, setter) => {
                         return {
-                        fullWidth: true,
-                        label: 'Copyright Notes',
-                        onChange: (
-                            e: React.SyntheticEvent<HTMLInputElement>
-                        ) => {
-                            setter(e.currentTarget.value);
-                        },
-                        value: state['copyright'] ?? '',
+                            fullWidth: true,
+                            label: 'Copyright Notes',
+                            onChange: (
+                                e: React.SyntheticEvent<HTMLInputElement>
+                            ) => {
+                                setter(e.currentTarget.value);
+                            },
+                            value: state['copyright'] ?? '',
                         };
                     },
                     field: 'copyright',
                     initialValue: '',
+                },
+                {
+                    component: (props) => (
+                        <>
+                            <Typography>Copyright Approved</Typography>
+                            <Checkbox {...props} />
+                        </>
+                    ),
+                    propFactory: (state, _r, setter) => {
+                        return {
+                            checked: state['copyrightApproved'],
+                            onChange: (
+                                _e: React.SyntheticEvent,
+                                checked: boolean,
+                            ) => {
+                                setter(checked);
+                            },
+                        };
+                    },
+                    field: 'copyrightApproved',
+                    initialValue: false,
                 },
                 {
                     component: TextField,

--- a/frontend/src/js/tabs/content/ContentForm.tsx
+++ b/frontend/src/js/tabs/content/ContentForm.tsx
@@ -60,7 +60,7 @@ function ContentForm({
     return (
         <ContentModal<Content>
             initialState={content}
-            items={[
+            fields={[
                 {
                     component: TextField,
                     propFactory: (state, reasons, setter) => {
@@ -77,7 +77,7 @@ function ContentForm({
                             value: state['title'],
                         };
                     },
-                    label: 'title',
+                    field: 'title',
                     initialValue: '',
                     validator: (state) => {
                         if (!state['title']) {
@@ -101,7 +101,7 @@ function ContentForm({
                             value: state['description'] ?? '',
                         };
                     },
-                    label: 'description',
+                    field: 'description',
                     initialValue: '',
                 },
                 {
@@ -144,7 +144,7 @@ function ContentForm({
                             error: reasons['file'],
                         };
                     },
-                    label: 'file',
+                    field: 'file',
                     initialValue: undefined,
                     validator: (state) => {
                         if (!state['file'] && !state['fileURL']) {
@@ -169,7 +169,7 @@ function ContentForm({
                             type: 'number',
                         };
                     },
-                    label: 'datePublished',
+                    field: 'datePublished',
                     initialValue: '',
                 },
                 {
@@ -186,7 +186,7 @@ function ContentForm({
                         value: state['copyright'] ?? '',
                         };
                     },
-                    label: 'copyright',
+                    field: 'copyright',
                     initialValue: '',
                 },
                 {
@@ -203,7 +203,7 @@ function ContentForm({
                             value: state['rightsStatement'] ?? '',
                         };
                     },
-                    label: 'rightsStatement',
+                    field: 'rightsStatement',
                     initialValue: '',
                 },
                 {
@@ -226,7 +226,7 @@ function ContentForm({
                             },
                         };
                     },
-                    label: 'metadata',
+                    field: 'metadata',
                     initialValue: {},
                 },
                 {
@@ -243,7 +243,7 @@ function ContentForm({
                             value: state['notes'] ?? '',
                         };
                     },
-                    label: 'notes',
+                    field: 'notes',
                     initialValue: '',
                 },
             ]}

--- a/frontend/src/js/tabs/content/SearchBar.tsx
+++ b/frontend/src/js/tabs/content/SearchBar.tsx
@@ -28,32 +28,32 @@ function SearchBar({
         <ContentSearch
             fields={[
                 {
-                    label: 'title',
+                    field: 'title',
                     title: 'Title',
                     type: 'string',
                     width: 4,
                 },
                 {
-                    label: 'fileName',
+                    field: 'fileName',
                     title: 'Filename',
                     type: 'string',
                     width: 4,
                 },
                 {
-                    label: 'copyright',
+                    field: 'copyright',
                     title: 'Copyright Notes',
                     type: 'string',
                     width: 4,
                 },
                 {
-                    label: 'years',
+                    field: 'years',
                     title: 'Years',
                     type: 'numeric',
                     width: 2,
                     min: 0,
                 },
                 {
-                    label: 'filesize',
+                    field: 'filesize',
                     title: 'Filesize',
                     type: 'numeric',
                     unit: 'MB',
@@ -61,7 +61,7 @@ function SearchBar({
                     min: 0,
                 },
                 {
-                    label: 'reviewed',
+                    field: 'reviewed',
                     title: 'Reviewed',
                     type: 'date',
                     width: 2,
@@ -69,7 +69,7 @@ function SearchBar({
                     parser: val => parseISO(val),
                 },
                 {
-                    label: 'active',
+                    field: 'active',
                     title: 'Active',
                     type: 'enum',
                     width: 2,
@@ -90,7 +90,7 @@ function SearchBar({
                     initialValue: 'all',
                 },
                 {
-                    label: 'duplicatable',
+                    field: 'duplicatable',
                     title: 'Duplicatable',
                     type: 'enum',
                     width: 2,
@@ -111,7 +111,7 @@ function SearchBar({
                     initialValue: 'all',
                 },
                 {
-                    label: 'metadata',
+                    field: 'metadata',
                     title: 'Metadata',
                     type: 'custom',
                     width: 12,

--- a/frontend/src/js/utils.ts
+++ b/frontend/src/js/utils.ts
@@ -58,13 +58,14 @@ export const contentToFormData = (content: Content): FormData => {
     );
     
     data.append('copyright_notes', content.copyright ?? '');
+    data.append('copyright_approved', content.copyrightApproved.toString());
     data.append('rights_statement', content.rightsStatement ?? '');
     data.append('additional_notes', content.notes ?? '');
 
     // Same format as DLMS, default to Jan. 1st
     // TODO: published_date should no longer be required on
     // the backend. Until then, a very improbable date will be
-    // assigned as a placeholder.
+    // assigned as a placeholder (0001-01-01).
     data.append('published_date', content.datePublished ? 
         `${content.datePublished.padStart(4, '0')}-01-01`
         :
@@ -76,7 +77,6 @@ export const contentToFormData = (content: Content): FormData => {
     // data.append('created_by', content.creator ?? 'admin');
     // data.append('created_on', format(Date.now(), 'yyyy-MM-dd'));
     // data.append('reviewed_by', '');
-    // data.append('copyright_approved', 'false');
     // data.append('copyright_by', '');
     // data.append('published_year', content.datePublished ?? '');
 


### PR DESCRIPTION
Refactored to account for solarspell-react-lib updates
Added Copyright Approved checkbox
Fixed simultaneous edit requests overwriting one another
