### PR TITLE
Fixed disappearing row select, reduced row options

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3621,7 +3621,6 @@
         "babel-polyfill": "^6.26.0",
         "babel-register": "^6.26.0",
         "babel-runtime": "^6.26.0",
-        "chokidar": "^1.6.1",
         "commander": "^2.11.0",
         "convert-source-map": "^1.5.0",
         "fs-readdir-recursive": "^1.0.0",
@@ -4448,7 +4447,6 @@
       "dependencies": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -5480,8 +5478,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -8308,7 +8305,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
@@ -12454,7 +12450,7 @@
     },
     "node_modules/solarspell-react-lib": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/SolarSPELL-Main/solarspell-react-lib.git#c154ae77bb9bb7de93e4a3428cddaa31c23058d4",
+      "resolved": "git+ssh://git@github.com/SolarSPELL-Main/solarspell-react-lib.git#6bf20879fd7d30289e3ff9111c33979f1253c795",
       "license": "ISC",
       "dependencies": {
         "@date-io/date-fns": "^1.3.13",
@@ -23576,7 +23572,7 @@
       }
     },
     "solarspell-react-lib": {
-      "version": "git+ssh://git@github.com/SolarSPELL-Main/solarspell-react-lib.git#c154ae77bb9bb7de93e4a3428cddaa31c23058d4",
+      "version": "git+ssh://git@github.com/SolarSPELL-Main/solarspell-react-lib.git#6bf20879fd7d30289e3ff9111c33979f1253c795",
       "from": "solarspell-react-lib@github:SolarSPELL-Main/solarspell-react-lib#main",
       "requires": {
         "@date-io/date-fns": "^1.3.13",

--- a/frontend/src/js/pages/content/Display.tsx
+++ b/frontend/src/js/pages/content/Display.tsx
@@ -155,7 +155,7 @@ function Display({
           // IDs that are not within its rows
           selectionModel: selected.filter(id => ids.includes(id)),
           onSelectionModelChange: actions.onSelectChange,
-          rowsPerPageOptions: [10, 25, 100, 500],
+          rowsPerPageOptions: [10, 25, 100],
           onPageSizeChange: actions.onPageSizeChange,
           onPageChange: actions.onPageChange,
           paginationMode: 'server',

--- a/frontend/src/js/theme.ts
+++ b/frontend/src/js/theme.ts
@@ -24,6 +24,31 @@ export default createMuiTheme({
             color: "primary"
         }
     },
+    overrides: {
+        MuiTablePagination: {
+            // A bit of a full sweep across all the components in the pagination
+            // component, but this ensures the row select and page indicator
+            // won't disappear on page resize.
+            caption: {
+                display: 'block !important',
+            },
+            actions: {
+                display: 'block !important',
+            },
+            selectIcon: {
+                display: 'block !important',
+            },
+            select: {
+                display: 'block !important',
+            },
+            selectRoot: {
+                display: 'block !important',
+            },
+            input: {
+                display: 'block !important',
+            },
+        },
+    },
     palette: {
         primary: {
             main: bright_blue


### PR DESCRIPTION
Added overrides to display: 'none' themes included by default in Material-UI for TablePagination components
Also removed 500 option from DataGrid, since free MIT version (our version) only supports up to 100 rows